### PR TITLE
Allow setting the vhost to a different value

### DIFF
--- a/src/rabbit_exchange_type_event.erl
+++ b/src/rabbit_exchange_type_event.erl
@@ -45,12 +45,15 @@ unregister() ->
     gen_event:delete_handler(rabbit_event, ?MODULE, []).
 
 x() ->
-    Result = application:get_env(rabbitmq_event_exchange, default_vhost),
-    case (Result) of
-      {ok, VHost } -> DefaultVHost = VHost;
-      undefined -> {ok, DefaultVHost} = application:get_env(rabbit, default_vhost)
+    case (application:get_env(rabbitmq_event_exchange, vhost)) of
+      undefined -> {ok, VHost} = application:get_env(rabbit, default_vhost);
+      {ok, VHost } -> ok
     end,
-    rabbit_misc:r(DefaultVHost, exchange, ?EXCH_NAME).
+    case (rabbit_vhost:exists(VHost)) of
+      false ->  rabbit_vhost:add(VHost);
+      _ -> ok
+    end,
+    rabbit_misc:r(VHost, exchange, ?EXCH_NAME).
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_exchange_type_event.erl
+++ b/src/rabbit_exchange_type_event.erl
@@ -45,7 +45,11 @@ unregister() ->
     gen_event:delete_handler(rabbit_event, ?MODULE, []).
 
 x() ->
-    {ok, DefaultVHost} = application:get_env(rabbit, default_vhost),
+    Result = application:get_env(rabbitmq_event_exchange, default_vhost),
+    case (Result) of
+      {ok, VHost } -> DefaultVHost = VHost;
+      undefined -> {ok, DefaultVHost} = application:get_env(rabbit, default_vhost)
+    end,
     rabbit_misc:r(DefaultVHost, exchange, ?EXCH_NAME).
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
I needed a way to set up the vhost of the exchange_event to a diferent value without changing the whole rabbit default_vhost. This allows configurations like:
```
[{rabbit , [...] },
 {rabbitmq_event_exchange, [{default_vhost, <<"another_thing">>}]}
]
```