### PR TITLE
Per AMQP 0-9-1 spec, timestamps must be in seconds

### DIFF
--- a/src/rabbit_exchange_type_event.erl
+++ b/src/rabbit_exchange_type_event.erl
@@ -62,7 +62,12 @@ handle_event(#event{type      = Type,
         ignore -> ok;
         Key    -> PBasic = #'P_basic'{delivery_mode = 2,
                                       headers = fmt_proplist(Props),
-                                      timestamp = TS},
+                                      %% 0-9-1 says the timestamp is a
+                                      %% "64 bit POSIX
+                                      %% timestamp". That's second
+                                      %% resolution, not millisecond.
+                                      timestamp = time_compat:convert_time_unit(
+                                                    TS, milli_seconds, seconds)},
                   Msg = rabbit_basic:message(x(), Key, PBasic, <<>>),
                   rabbit_basic:publish(
                     rabbit_basic:delivery(false, false, Msg, undefined))

--- a/test/src/rabbit_exchange_type_event_test.erl
+++ b/test/src/rabbit_exchange_type_event_test.erl
@@ -41,7 +41,7 @@ simple_test() ->
     receive
         {#'basic.deliver'{routing_key = Key},
          #amqp_msg{props = #'P_basic'{headers = Headers, timestamp = TS}}} ->
-            %% timestamp is in the last 5 seconds
+            %% timestamp is within the last 5 seconds
             ?assert((TS - Now) =< 5),
             ?assertMatch(<<"queue.created">>, Key),
             ?assertMatch({longstr, Q2}, rabbit_misc:table_lookup(

--- a/test/src/rabbit_exchange_type_event_test.erl
+++ b/test/src/rabbit_exchange_type_event_test.erl
@@ -21,6 +21,7 @@
 
 %% Only really tests that we're not completely broken.
 simple_test() ->
+    Now = time_compat:os_system_time(seconds),
     {ok, Conn} = amqp_connection:start(#amqp_params_network{}),
     {ok, Ch} = amqp_connection:open_channel(Conn),
     #'queue.declare_ok'{queue = Q} =
@@ -39,7 +40,9 @@ simple_test() ->
 
     receive
         {#'basic.deliver'{routing_key = Key},
-         #amqp_msg{props = #'P_basic'{headers = Headers}}} ->
+         #amqp_msg{props = #'P_basic'{headers = Headers, timestamp = TS}}} ->
+            %% timestamp is in the last 5 seconds
+            ?assert((TS - Now) =< 5),
             ?assertMatch(<<"queue.created">>, Key),
             ?assertMatch({longstr, Q2}, rabbit_misc:table_lookup(
                                           Headers, <<"name">>))


### PR DESCRIPTION
It really makes little sense for event collection but in this case
we must obey by the specs, as clients expect seconds resolution.

Fixes #8.