### PR TITLE
Performance optimisations

### DIFF
--- a/include/rabbit_event_exchange.hrl
+++ b/include/rabbit_event_exchange.hrl
@@ -1,0 +1,1 @@
+-define(EXCH_NAME, <<"amq.rabbitmq.event">>).

--- a/src/rabbit_event_exchange_decorator.erl
+++ b/src/rabbit_event_exchange_decorator.erl
@@ -1,0 +1,77 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_event_exchange_decorator).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include("rabbit_event_exchange.hrl").
+
+-rabbit_boot_step({?MODULE,
+                   [{description, "event exchange decorator"},
+                    {mfa, {rabbit_registry, register,
+                           [exchange_decorator, <<"event">>, ?MODULE]}},
+                    {requires, rabbit_registry},
+                    {cleanup, {rabbit_registry, unregister,
+                               [exchange_decorator, <<"event">>]}},
+                    {enables, recovery}]}).
+
+-behaviour(rabbit_exchange_decorator).
+
+-export([description/0, serialise_events/1]).
+-export([create/2, delete/3, policy_changed/2,
+         add_binding/3, remove_bindings/3, route/2, active_for/1]).
+
+description() ->
+    [{description, <<"Event exchange decorator">>}].
+
+serialise_events(_) -> false.
+
+create(_, _) ->
+    ok.
+
+delete(_, _, _) ->
+    ok.
+
+policy_changed(_, _) ->
+    ok.
+
+add_binding(transaction, #exchange{name = #resource{name = ?EXCH_NAME} = Name},
+            _Bs) ->
+    case rabbit_binding:list_for_source(Name) of
+        [_] ->
+            rabbit_event ! {event_exchange, added_first_binding},
+            ok;
+        _ ->
+            ok
+    end;
+add_binding(_, _X, _Bs) ->
+    ok.
+
+remove_bindings(transaction, #exchange{name = #resource{name = ?EXCH_NAME} = Name},
+                _Bs) ->
+    case rabbit_binding:list_for_source(Name) of
+        [] ->
+            rabbit_event ! {event_exchange, removed_last_binding},
+            ok;
+        _ ->
+            ok
+    end;
+remove_bindings(_, _X, _Bs) ->
+    ok.
+
+route(_, _) -> [].
+
+active_for(_) -> noroute.

--- a/src/rabbit_exchange_type_event.erl
+++ b/src/rabbit_exchange_type_event.erl
@@ -28,7 +28,7 @@
 -export([fmt_proplist/1]). %% testing
 
 -record(state, {vhost,
-                has_binding
+                has_any_bindings
                }).
 
 -rabbit_boot_step({rabbit_event_exchange,
@@ -65,16 +65,16 @@ exchange(VHost) ->
 init([]) ->
     VHost = get_vhost(),
     X = rabbit_misc:r(VHost, exchange, ?EXCH_NAME),
-    HasBinding = case rabbit_binding:list_for_source(X) of
+    HasBindings = case rabbit_binding:list_for_source(X) of
                      [] -> false;
                      _ -> true
                  end,
     {ok, #state{vhost = VHost,
-                has_binding = HasBinding}}.
+                has_any_bindings = HasBindings}}.
 
 handle_call(_Request, State) -> {ok, not_understood, State}.
 
-handle_event(_, #state{has_binding = false} = State) ->
+handle_event(_, #state{has_any_bindings = false} = State) ->
     {ok, State};
 handle_event(#event{type      = Type,
                     props     = Props,
@@ -101,9 +101,9 @@ handle_event(_Event, State) ->
     {ok, State}.
 
 handle_info({event_exchange, added_first_binding}, State) ->
-    {ok, State#state{has_binding = true}};
+    {ok, State#state{has_any_bindings = true}};
 handle_info({event_exchange, removed_last_binding}, State) ->
-    {ok, State#state{has_binding = false}};
+    {ok, State#state{has_any_bindings = false}};
 handle_info(_Info, State) -> {ok, State}.
 
 terminate(_Arg, _State) -> ok.

--- a/src/rabbit_exchange_type_event.erl
+++ b/src/rabbit_exchange_type_event.erl
@@ -105,6 +105,85 @@ ensure_vhost_exists() ->
     end,
     VHost.
 
+%% pattern matching is way more efficient that the string operations,
+%% let's use all the keys we're aware of to speed up the handler.
+%% Any unknown or new one will be processed as before (see last function clause).
+key(queue_deleted) ->
+    <<"queue.deleted">>;
+key(queue_created) ->
+    <<"queue.created">>;
+key(exchange_created) ->
+    <<"exchange.created">>;
+key(exchange_deleted) ->
+    <<"exchange.deleted">>;
+key(binding_created) ->
+    <<"binding.created">>;
+key(connection_created) ->
+    <<"connection.created">>;
+key(connection_closed) ->
+    <<"connection.closed">>;
+key(channel_created) ->
+    <<"channel.created">>;
+key(channel_closed) ->
+    <<"channel.closed">>;
+key(consumer_created) ->
+    <<"consumer.created">>;
+key(consumer_deleted) ->
+    <<"consumer.deleted">>;
+key(queue_stats) ->
+    ignore;
+key(connection_stats) ->
+    ignore;
+key(policy_set) ->
+    <<"policy.set">>;
+key(policy_cleared) ->
+    <<"policy.cleared">>;
+key(parameter_set) ->
+    <<"parameter.set">>;
+key(parameter_cleared) ->
+    <<"parameter.cleared">>;
+key(vhost_created) ->
+    <<"vhost.created">>;
+key(vhost_deleted) ->
+    <<"vhost.deleted">>;
+key(vhost_limits_set) ->
+    <<"vhost.limits.set">>;
+key(vhost_limits_cleared) ->
+    <<"vhost.limits.cleared">>;
+key(user_authentication_success) ->
+    <<"user.authentication.success">>;
+key(user_authentication_failure) ->
+    <<"user.authentication.failure">>;
+key(user_created) ->
+    <<"user.created">>;
+key(user_deleted) ->
+    <<"user.deleted">>;
+key(user_password_changed) ->
+    <<"user.password.changed">>;
+key(user_password_cleared) ->
+    <<"user.password.cleared">>;
+key(user_tags_set) ->
+    <<"user.tags.set">>;
+key(permission_created) ->
+    <<"permission.created">>;
+key(permission_deleted) ->
+    <<"permission.deleted">>;
+key(topic_permission_created) ->
+    <<"topic.permission.created">>;
+key(topic_permission_deleted) ->
+    <<"topic.permission.deleted">>;
+key(alarm_set) ->
+    <<"alarm.set">>;
+key(alarm_cleared) ->
+    <<"alarm.cleared">>;
+key(shovel_worker_status) ->
+    <<"shovel.worker.status">>;
+key(shovel_worker_removed) ->
+    <<"shovel.worker.removed">>;
+key(federation_link_status) ->
+    <<"federation.link.status">>;
+key(federation_link_removed) ->
+    <<"federation.link.removed">>;
 key(S) ->
     case string:tokens(atom_to_list(S), "_") of
         [_, "stats"] -> ignore;

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -17,14 +17,18 @@
 -module(unit_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
 
 all() -> [ encoding ].
 
 encoding(_) ->
-    T = fun (In, Exp) -> 
-                true = (rabbit_exchange_type_event:fmt_proplist(In) == Exp) end,
+    T = fun (In, Exp) ->
+                ?assertEqual(
+                   lists:sort(rabbit_exchange_type_event:fmt_proplist(In)),
+                   lists:sort(Exp))
+        end,
     T([{name, <<"test">>}],
       [{<<"name">>, longstr, <<"test">>}]),
     T([{name, rabbit_misc:r(<<"/">>, exchange, <<"test">>)}],
@@ -52,8 +56,8 @@ encoding(_) ->
                                   {array, [{longstr, <<"a">>},
                                            {longstr, <<"b">>}]}]},
        {<<"proplist">>, table,
-        [{<<"foo">>, longstr, <<"a">>},
-         {<<"bar">>, table,   [{<<"baz">>,  longstr, <<"b">>},
-                               {<<"bash">>, longstr, <<"c">>}]}]}       
+        [{<<"bar">>, table,   [{<<"bash">>, longstr, <<"c">>},
+                               {<<"baz">>, longstr, <<"b">>}]},
+         {<<"foo">>, longstr, <<"a">>}]}
       ]),
     ok.


### PR DESCRIPTION
These changes up to commit https://github.com/rabbitmq/rabbitmq-event-exchange/pull/36/commits/af5c3f80d6d8f8de736958805885aeb0aee60ee5 provide ~35% optimization when no queues are bind to the event exchange, and ~30% in other case.
The decorator introduced in https://github.com/rabbitmq/rabbitmq-event-exchange/pull/36/commits/bd67fddfb0178cec9b5ca834fab1c15d1290ce26 provides a total 88% optimization when no queues are bind to the event exchange, no change in the other case.
Tested with 4M messages: 50% stats that are ignored, 25% events that can't be routed and 25% events that will be routed if the bound queue is present.

Part of https://github.com/rabbitmq/rabbitmq-server/issues/1722. The `gen_event` doesn't seem to be the main problem, but the handlers installed such as this plugin. It can build a massive message queue even when no queues are bind to the event exchange, with the configuration mentioned it takes 40s to drop all the 4M messages.

Same as https://github.com/rabbitmq/rabbitmq-event-exchange/pull/36